### PR TITLE
implemented user_version handling on database connection to be consistent through all platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -319,6 +319,9 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
   <tr>
     <td align="center"><a href="https://github.com/jepiqueau"><img src="https://avatars3.githubusercontent.com/u/16580653?v=4" width="100px;" alt=""/><br /><sub><b>Jean Pierre Quéau</b></sub></a><br /><a href="https://github.com/capacitor-community/sqlite/commits?author=jepiqueau" title="Code">💻</a></td>
   </tr>
+  <tr>
+    <td align="center"><a href="https://github.com/karyfars"><img src="https://avatars3.githubusercontent.com/u/303016" width="100px;" alt=""/><br /><sub><b>Adam</b></sub></a><br /><a href="https://github.com/capacitor-community/sqlite/commits?author=karyfars" title="Code">💻</a></td>
+  </tr>
 </table>
 
 <!-- markdownlint-enable -->

--- a/android/src/main/java/com/getcapacitor/community/database/sqlite/CapacitorSQLite.java
+++ b/android/src/main/java/com/getcapacitor/community/database/sqlite/CapacitorSQLite.java
@@ -64,6 +64,7 @@ public class CapacitorSQLite extends Plugin {
         String secret = null;
         String newsecret = null;
         String inMode = null;
+        int dbVersion = 1;
         JSObject ret = new JSObject();
         Log.v(TAG, "*** in open " + isPermissionGranted + " ***");
         if (!isPermissionGranted) {
@@ -75,6 +76,7 @@ public class CapacitorSQLite extends Plugin {
             retResult(call, false, "Open command failed: Must provide a database name");
             return;
         }
+        dbVersion = call.getInt("version", 1);
         boolean encrypted = call.getBoolean("encrypted", false);
         if (encrypted) {
             inMode = call.getString("mode", "no-encryption");
@@ -106,7 +108,7 @@ public class CapacitorSQLite extends Plugin {
             inMode = "no-encryption";
             secret = "";
         }
-        mDb = new SQLiteDatabaseHelper(context, dbName + "SQLite.db", encrypted, inMode, secret, newsecret, 1);
+        mDb = new SQLiteDatabaseHelper(context, dbName + "SQLite.db", encrypted, inMode, secret, newsecret, dbVersion);
         if (!mDb.isOpen) {
             retResult(call, false, "Open command failed: Database " + dbName + "SQLite.db not opened");
         } else {

--- a/ios/Plugin/DatabaseSQLiteHelper.swift
+++ b/ios/Plugin/DatabaseSQLiteHelper.swift
@@ -63,6 +63,7 @@ class DatabaseHelper {
     // define the path for the database
     var path: String = ""
     var databaseName: String
+    var databaseVersion: Int
     var secret: String
     var newsecret: String
     var encrypted: Bool
@@ -71,13 +72,14 @@ class DatabaseHelper {
     // MARK: - Init
 
     init(databaseName: String, encrypted: Bool = false, mode: String = "no-encryption",
-         secret: String = "", newsecret: String = "") throws {
+         secret: String = "", newsecret: String = "", databaseVersion: Int = 1) throws {
         print("databaseName: \(databaseName) ")
         self.secret = secret
         self.newsecret = newsecret
         self.encrypted = encrypted
         self.databaseName = databaseName
         self.mode = mode
+        self.databaseVersion = databaseVersion
         do {
             self.path = try UtilsSQLite.getFilePath(fileName: databaseName)
         } catch UtilsSQLiteError.filePathFailed {
@@ -88,7 +90,7 @@ class DatabaseHelper {
 
         let message: String = UtilsSQLite.createConnection(dbHelper: self, path: self.path, mode: self.mode,
                                                             encrypted: self.encrypted, secret: self.secret,
-                                                            newsecret: self.newsecret)
+                                                            newsecret: self.newsecret, version: self.databaseVersion)
         self.isOpen = message.count == 0 || message == "swap newsecret" ||
                  message == "success encryption" ? true : false
 
@@ -126,7 +128,7 @@ class DatabaseHelper {
         var ret: Bool = false
         var mDB: OpaquePointer?
         do {
-            try mDB = UtilsSQLite.connection(filename: self.path)
+            try mDB = UtilsSQLite.connection(filename: self.path, version: self.databaseVersion)
             isOpen = true
             closeDB(mDB: mDB, method: "init")
             isOpen = false
@@ -146,7 +148,7 @@ class DatabaseHelper {
 
     func execSQL(sql: String) throws -> Int {
         guard let mDB: OpaquePointer = try UtilsSQLite.getWritableDatabase(filename: self.path,
-                    secret: secret) else {
+                    secret: secret, version: self.databaseVersion) else {
             throw DatabaseHelperError.dbConnection(message: "Error: DB connection")
         }
         var changes: Int = 0
@@ -182,7 +184,7 @@ class DatabaseHelper {
 
     func execSet(set: [[String: Any]]) throws -> Int {
         guard let mDB: OpaquePointer = try UtilsSQLite.getWritableDatabase(filename: self.path,
-                    secret: secret) else {
+                    secret: secret, version: self.databaseVersion) else {
             throw DatabaseHelperError.dbConnection(message: "Error: DB connection")
         }
         var changes: Int = 0
@@ -238,7 +240,7 @@ class DatabaseHelper {
 
     func runSQL(sql: String, values: [Any]) throws -> [String: Int] {
         guard let mDB: OpaquePointer = try UtilsSQLite.getWritableDatabase(filename: self.path,
-                    secret: secret) else {
+                    secret: secret, version: self.databaseVersion) else {
             throw DatabaseHelperError.dbConnection(message: "Error: DB connection")
         }
         var message: String = ""
@@ -458,7 +460,7 @@ class DatabaseHelper {
         var retObj: Int = -1
         // Open the database for writing
         guard let mDB: OpaquePointer = try UtilsSQLite.getWritableDatabase(filename: self.path,
-                    secret: secret) else {
+                    secret: secret, version: self.databaseVersion) else {
             throw DatabaseHelperError.dbConnection(message: "Error: DB connection")
         }
         // check if the table has already been created
@@ -494,7 +496,7 @@ class DatabaseHelper {
         var retBool: Bool = false
         // Open the database for writing
         guard let mDB: OpaquePointer = try UtilsSQLite.getWritableDatabase(filename: self.path,
-                    secret: secret) else {
+                    secret: secret, version: self.databaseVersion) else {
             throw DatabaseHelperError.dbConnection(message: "Error: DB connection")
         }
         do {

--- a/ios/Plugin/Plugin.swift
+++ b/ios/Plugin/Plugin.swift
@@ -349,10 +349,11 @@ public class CapacitorSQLite: CAPPlugin {
                 let jsonSQLite = try JSONDecoder().decode([JsonSQLite].self, from: data)
                 let secret: String = jsonSQLite[0].encrypted ? globalData.secret : ""
                 let inMode: String = jsonSQLite[0].encrypted ? "secret" : "no-encryption"
+                var dbVersion: Int = call.getInt("version", 1) ?? 1
                 do {
                    mDb = try DatabaseHelper(databaseName: jsonSQLite[0].database + "SQLite.db",
                                             encrypted: jsonSQLite[0].encrypted, mode: inMode, secret: secret,
-                                            newsecret: "")
+                                            newsecret: "", databaseVersion: dbVersion)
                 } catch let error {
                     retHandler.rChanges(call: call, ret: ["changes": -1],
                         message: "ImportFromJson command failed : " + error.localizedDescription)

--- a/ios/Plugin/Plugin.swift
+++ b/ios/Plugin/Plugin.swift
@@ -37,6 +37,7 @@ public class CapacitorSQLite: CAPPlugin {
         var inMode: String = ""
         var secretKey: String = ""
         var newsecretKey: String = ""
+        var dbVersion: Int = call.getInt("version", 1) ?? 1;
         if encrypted {
             inMode = call.getString("mode") ?? "no-encryption"
             if inMode != "no-encryption" && inMode != "encryption" && inMode != "secret"
@@ -65,7 +66,7 @@ public class CapacitorSQLite: CAPPlugin {
         }
         do {
            mDb = try DatabaseHelper(databaseName: "\(dbName)SQLite.db", encrypted: encrypted,
-                mode: inMode, secret: secretKey, newsecret: newsecretKey)
+                mode: inMode, secret: secretKey, newsecret: newsecretKey, databaseVersion: dbVersion)
         } catch let error {
             retHandler.rResult(call: call, ret: false, message: "Open command failed: \(error)")
         }

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -116,6 +116,10 @@ export interface capSQLiteOptions {
    */
   mode?: string;
   /***
+   * Set Database Version
+   */
+  version?: number;
+  /***
    * Set the JSON object to import
    *
    */

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -83,6 +83,16 @@ export interface CapacitorSQLitePlugin {
    * @returns {Promise<capSQLiteResult>} {result:boolean}
    */
   setSyncDate(options: capSQLiteOptions): Promise<capSQLiteResult>;
+  /**
+   * Add an upgrade statement
+   * @param {string} database Database Name
+   * @param {capSQLiteVersionUpgrade} upgrade {fromVersion: number, toVersion: number, statement?: string, set?: Array<capSQLiteSet>}
+   * @returns {Promise<void>}
+   */
+  addUpgradeStatement(
+    database: string,
+    upgrade: capSQLiteVersionUpgrade,
+  ): Promise<void>;
 }
 
 export interface capSQLiteOptions {
@@ -168,4 +178,11 @@ export interface capSQLiteSet {
    * the data values list as an Array
    */
   values?: Array<any>;
+}
+
+export interface capSQLiteVersionUpgrade {
+  fromVersion: number;
+  toVersion: number;
+  statement?: string;
+  set?: Array<capSQLiteSet>;
 }

--- a/src/electron-utils/DatabaseSQLiteHelper.ts
+++ b/src/electron-utils/DatabaseSQLiteHelper.ts
@@ -13,6 +13,7 @@ const fs: any = window['fs' as any];
 export class DatabaseSQLiteHelper {
   public isOpen: boolean = false;
   private _databaseName: string;
+  private _databaseVersion: number;
   //    private _encrypted: boolean;
   //    private _mode: string;
   //    private _secret: string = "";
@@ -20,11 +21,13 @@ export class DatabaseSQLiteHelper {
   private _utils: UtilsSQLite;
 
   constructor(
-    dbName: string /*, encrypted:boolean = false, mode:string = "no-encryption",
+    dbName: string,
+    dbVersion = 1 /*, encrypted:boolean = false, mode:string = "no-encryption",
         secret:string = "",newsecret:string=""*/,
   ) {
     this._utils = new UtilsSQLite();
     this._databaseName = dbName;
+    this._databaseVersion = dbVersion;
     //        this._encrypted = encrypted;
     //        this._mode = mode;
     //        this._secret = secret;
@@ -34,7 +37,8 @@ export class DatabaseSQLiteHelper {
   private _openDB() {
     const db = this._utils.connection(
       this._databaseName,
-      false /*,this._secret*/,
+      false,
+      this._databaseVersion /*,this._secret*/,
     );
     if (db != null) {
       this.isOpen = true;
@@ -49,7 +53,8 @@ export class DatabaseSQLiteHelper {
       let retRes = { changes: -1 };
       const db = this._utils.connection(
         this._databaseName,
-        false /*,this._secret*/,
+        false,
+        this._databaseVersion /*,this._secret*/,
       );
       if (db === null) {
         this.isOpen = false;
@@ -80,7 +85,8 @@ export class DatabaseSQLiteHelper {
       let ret: boolean = false;
       const db = this._utils.connection(
         this._databaseName,
-        false /*,this._secret*/,
+        false,
+        this._databaseVersion /*,this._secret*/,
       );
       if (db === null) {
         this.isOpen = false;
@@ -98,7 +104,11 @@ export class DatabaseSQLiteHelper {
 
   public close(databaseName: string): Promise<boolean> {
     return new Promise(resolve => {
-      const db = this._utils.connection(databaseName, false /*,this._secret*/);
+      const db = this._utils.connection(
+        databaseName,
+        false,
+        this._databaseVersion /*,this._secret*/,
+      );
       if (db === null) {
         this.isOpen = false;
         console.log('close: Error Database connection failed');
@@ -121,7 +131,8 @@ export class DatabaseSQLiteHelper {
       let retRes = { changes: -1 };
       const db = this._utils.connection(
         this._databaseName,
-        false /*,this._secret*/,
+        false,
+        this._databaseVersion /*,this._secret*/,
       );
       if (db === null) {
         this.isOpen = false;
@@ -156,7 +167,8 @@ export class DatabaseSQLiteHelper {
       let retRes: any = { changes: -1, lastId: lastId };
       const db = this._utils.connection(
         this._databaseName,
-        false /*,this._secret*/,
+        false,
+        this._databaseVersion /*,this._secret*/,
       );
       if (db === null) {
         this.isOpen = false;
@@ -203,7 +215,8 @@ export class DatabaseSQLiteHelper {
       let retRes: any = { changes: -1, lastId: lastId };
       const db = this._utils.connection(
         this._databaseName,
-        false /*,this._secret*/,
+        false,
+        this._databaseVersion /*,this._secret*/,
       );
       if (db === null) {
         this.isOpen = false;
@@ -280,7 +293,8 @@ export class DatabaseSQLiteHelper {
     return new Promise(async resolve => {
       const db = this._utils.connection(
         this._databaseName,
-        true /*,this._secret*/,
+        true,
+        this._databaseVersion /*,this._secret*/,
       );
       if (db === null) {
         this.isOpen = false;
@@ -476,7 +490,8 @@ export class DatabaseSQLiteHelper {
       let isValue: boolean = false;
       const db = this._utils.connection(
         this._databaseName,
-        false /*,this._secret*/,
+        false,
+        this._databaseVersion /*,this._secret*/,
       );
       if (db === null) {
         this.isOpen = false;
@@ -766,7 +781,11 @@ export class DatabaseSQLiteHelper {
     return new Promise(async resolve => {
       let success: boolean = true;
       const databaseName: string = `${retJson.database}SQLite.db`;
-      const db = this._utils.connection(databaseName, false /*,this._secret*/);
+      const db = this._utils.connection(
+        databaseName,
+        false,
+        this._databaseVersion /*,this._secret*/,
+      );
       if (db === null) {
         this.isOpen = false;
         console.log('createJsonTables: Error Database connection failed');

--- a/src/electron-utils/UtilsSQLite.ts
+++ b/src/electron-utils/UtilsSQLite.ts
@@ -1,4 +1,3 @@
-const sqlite3: any = window['sqlite3' as any];
 const fs: any = window['fs' as any];
 const path: any = window['path' as any];
 const appName: any = window['appName' as any];
@@ -8,85 +7,6 @@ export class UtilsSQLite {
   public pathDB: string = 'Databases';
 
   constructor() {}
-
-  public connection(
-    dbName: string,
-    readOnly?: boolean,
-    dbVersion = 1 /*,key?:string*/,
-  ): any {
-    const flags = readOnly
-      ? sqlite3.OPEN_READONLY
-      : sqlite3.OPEN_CREATE | sqlite3.OPEN_READWRITE;
-
-    // get the path for the database
-    const dbPath = this.getDBPath(dbName);
-    let dbOpen: any = null;
-
-    if (dbPath.length > 0) {
-      try {
-        dbOpen = new sqlite3.Database(dbPath, flags);
-      } catch (e) {
-        console.log('Error: in UtilsSQLite.connection ', e);
-        dbOpen = null;
-      } finally {
-        if (dbOpen != null) {
-          const statements: string = 'PRAGMA foreign_keys = ON;';
-          dbOpen.serialize(() => {
-            dbOpen.exec(statements, (err: Error) => {
-              if (err) {
-                console.log(
-                  `exec: Error PRAGMA foreign_keys failed : ${err.message}`,
-                );
-                dbOpen = null;
-              }
-            });
-          });
-
-          const versionStatement: string = 'PRAGMA user_version;';
-          dbOpen.serialize(() => {
-            dbOpen.get(versionStatement, (err: Error, row: any) => {
-              if (err) {
-                console.log(
-                  `get: Error PRAGMA user_version failed : ${err.message}`,
-                );
-                dbOpen = null;
-                return;
-              }
-
-              if (row === undefined || row['user_version'] === 0) {
-                dbOpen.run('PRAGMA user_version = $version;', {
-                  $version: dbVersion,
-                });
-              } else if (row['user_version'] !== dbVersion) {
-                console.log(
-                  `Error PRAGMA user_version failed : Version mismatch expected Version ${dbVersion} found Version ${row['user_version']}`,
-                );
-                dbOpen = null;
-                return;
-              }
-            });
-          });
-        }
-        return dbOpen;
-      }
-    }
-  }
-
-  public getWritableDatabase(
-    dbName: string,
-    dbVersion = 1 /*, secret: string*/,
-  ): any {
-    const db: any = this.connection(dbName, false, dbVersion /*,secret*/);
-    return db;
-  }
-
-  public getReadableDatabase(
-    dbName: string,
-    dbVersion = 1 /*, secret: string*/,
-  ): any {
-    const db: any = this.connection(dbName, true, dbVersion /*,secret*/);
-    return db;
-  }
 
   public getDBPath(dbName: string): string {
     let retPath: string = '';

--- a/src/electron.ts
+++ b/src/electron.ts
@@ -32,6 +32,7 @@ export class CapacitorSQLitePluginElectron extends WebPlugin
       });
     }
     const dbName: string = options.database;
+    const dbVersion: number = options.version ?? 1;
     /*
         let encrypted: boolean = options.encrypted ? options.encrypted : false;
         let inMode: string = "no-encryption";
@@ -39,7 +40,8 @@ export class CapacitorSQLitePluginElectron extends WebPlugin
         let newsecretKey: string = "";
         */
     this.mDb = new DatabaseSQLiteHelper(
-      `${dbName}SQLite.db` /*,encrypted,inMode,secretKey,newsecretKey*/,
+      `${dbName}SQLite.db`,
+      dbVersion /*,encrypted,inMode,secretKey,newsecretKey*/,
     );
     if (!this.mDb.isOpen) {
       return Promise.reject({

--- a/src/web.ts
+++ b/src/web.ts
@@ -3,6 +3,7 @@ import {
   CapacitorSQLitePlugin,
   capSQLiteOptions,
   capSQLiteResult,
+  capSQLiteVersionUpgrade,
 } from './definitions';
 
 export class CapacitorSQLiteWeb extends WebPlugin
@@ -69,6 +70,13 @@ export class CapacitorSQLiteWeb extends WebPlugin
   }
   async setSyncDate(options: capSQLiteOptions): Promise<capSQLiteResult> {
     console.log('setSyncDate', options);
+    return Promise.reject('Not implemented');
+  }
+  async addUpgradeStatement(
+    database: string,
+    upgrade: capSQLiteVersionUpgrade,
+  ): Promise<void> {
+    console.log('addUpgradeStatement', database, upgrade);
     return Promise.reject('Not implemented');
   }
 }


### PR DESCRIPTION
On Android SQLCipher uses the PRAGMA user_version for version handling and refused connections to databases with user_version other than 1.

- Added version option to open statement (defaults to 1)
- implemented behavior of SQLCipher on Android to electron and ios versions, to make the experience consistent through out all platforms
- connection to versioned databases on android is possible now
