### PR TITLE
Fix for passing null values as parameter in INSERT queries on iOS (#56)

### DIFF
--- a/ios/Plugin/Plugin.swift
+++ b/ios/Plugin/Plugin.swift
@@ -264,7 +264,7 @@ public class CapacitorSQLite: CAPPlugin {
                             val.append(obj)
                         } else if let obj = value as? Float {
                             val.append(obj)
-			} else if value is NSNull {
+                        } else if value is NSNull {
                             val.append("NULL")
                         } else {
                             var msg: String = "Run command failed : "

--- a/ios/Plugin/Plugin.swift
+++ b/ios/Plugin/Plugin.swift
@@ -264,6 +264,8 @@ public class CapacitorSQLite: CAPPlugin {
                             val.append(obj)
                         } else if let obj = value as? Float {
                             val.append(obj)
+			} else if value is NSNull {
+                            val.append("NULL")
                         } else {
                             var msg: String = "Run command failed : "
                             msg.append("Not a SQL type")


### PR DESCRIPTION
This PR fixes the issue described in #56 . The plugin wasn't checking if the value was of type ``NSNull``, leading to the error when trying to pass null values.

It has been replaced by a "NULL" insert. I've verified that SQLite properly inserts now the value as a NULL record.