### PR TITLE
feat: added `clearEncryptionSecret` method (implements #283)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 3.5.1-3
+
+### Added Features
+
+ - added method `clearEncryptionSecret` to reset a previously saved passphrase in the keychain (issue #283)
+
 # 3.5.1-2 (2022-05-31)
 
 ### Bug Fixes

--- a/android/src/main/java/com/getcapacitor/community/database/sqlite/CapacitorSQLite.java
+++ b/android/src/main/java/com/getcapacitor/community/database/sqlite/CapacitorSQLite.java
@@ -263,6 +263,25 @@ public class CapacitorSQLite {
         }
     }
 
+    /**
+     * ClearEncryptionSecret
+     * @throws Exception
+     */
+    public void clearEncryptionSecret() throws Exception {
+        if (isEncryption) {
+            try {
+                // close all connections
+                closeAllConnections();
+                // set encryption secret
+                uSecret.clearEncryptionSecret();
+            } catch (Exception e) {
+                throw new Exception(e.getMessage());
+            }
+        } else {
+            throw new Exception("No Encryption set in capacitor.config");
+        }
+    }    
+
     public String getNCDatabasePath(String folderPath, String database) throws Exception {
         try {
             String databasePath = uNCDatabase.getNCDatabasePath(context, folderPath, database);

--- a/android/src/main/java/com/getcapacitor/community/database/sqlite/CapacitorSQLitePlugin.java
+++ b/android/src/main/java/com/getcapacitor/community/database/sqlite/CapacitorSQLitePlugin.java
@@ -175,6 +175,30 @@ public class CapacitorSQLitePlugin extends Plugin {
         }
     }
 
+    /**
+     * ClearEncryptionSecret
+     * clear the passphrase secret for a database
+     *
+     * @param call
+     */
+    @PluginMethod
+    public void clearEncryptionSecret(PluginCall call) {
+        if (implementation != null) {
+            try {
+                implementation.clearEncryptionSecret();
+                rHandler.retResult(call, null, null);
+                return;
+            } catch (Exception e) {
+                String msg = "ClearEncryptionSecret: " + e.getMessage();
+                rHandler.retResult(call, null, msg);
+                return;
+            }
+        } else {
+            rHandler.retResult(call, null, loadMessage);
+            return;
+        }
+    }
+
     @PluginMethod
     public void getNCDatabasePath(PluginCall call) {
         String folderPath = null;

--- a/android/src/main/java/com/getcapacitor/community/database/sqlite/SQLite/UtilsSecret.java
+++ b/android/src/main/java/com/getcapacitor/community/database/sqlite/SQLite/UtilsSecret.java
@@ -111,6 +111,23 @@ public class UtilsSecret {
         }
     }
 
+    /**
+     * ClearEncryptionSecret
+     * @throws Exception
+     */
+    public void clearEncryptionSecret() throws Exception {
+        try {
+            // test if Encryption secret is already set
+            String savedPassPhrase = getPassphrase();
+            if (savedPassPhrase != null && savedPassPhrase.length() > 0) {
+                // Clear encrypted passphrase in sharedPreferences
+                clearPassphrase();
+            }
+        } catch (Exception e) {
+            throw new Exception(e.getMessage());
+        }
+    }
+
     public void setPassphrase(String passphrase) {
         sharedPreferences.edit().putString("secret", passphrase).apply();
     }
@@ -118,5 +135,9 @@ public class UtilsSecret {
     public String getPassphrase() {
         String passphrase = sharedPreferences.getString("secret", "");
         return passphrase;
+    }
+
+    public void clearPassphrase() {
+        sharedPreferences.edit().remove("secret").commit();
     }
 }

--- a/docs/API.md
+++ b/docs/API.md
@@ -118,6 +118,7 @@ The plugin add a suffix "SQLite" and an extension ".db" to the database name giv
 * [`isSecretStored()`](#issecretstored)
 * [`setEncryptionSecret(...)`](#setencryptionsecret)
 * [`changeEncryptionSecret(...)`](#changeencryptionsecret)
+* [`clearEncryptionSecret()`](#clearencryptionsecret)
 * [`createConnection(...)`](#createconnection)
 * [`closeConnection(...)`](#closeconnection)
 * [`echo(...)`](#echo)
@@ -244,6 +245,19 @@ in secure store
 | **`options`** | <code><a href="#capchangesecretoptions">capChangeSecretOptions</a></code> | <a href="#capchangesecretoptions">capChangeSecretOptions</a> |
 
 **Since:** 3.0.0-beta.13
+
+--------------------
+
+
+### clearEncryptionSecret()
+
+```typescript
+clearEncryptionSecret() => Promise<void>
+```
+
+Clear the passphrase in the secure store
+
+**Since:** 3.5.1-3
 
 --------------------
 

--- a/docs/APIConnection.md
+++ b/docs/APIConnection.md
@@ -14,6 +14,7 @@
 * [`isSecretStored()`](#issecretstored)
 * [`setEncryptionSecret(...)`](#setencryptionsecret)
 * [`changeEncryptionSecret(...)`](#changeencryptionsecret)
+* [`clearEncryptionSecret()`](#clearencryptionsecret)
 * [`addUpgradeStatement(...)`](#addupgradestatement)
 * [`createConnection(...)`](#createconnection)
 * [`isConnection(...)`](#isconnection)
@@ -142,6 +143,19 @@ Change the passphrase in a secure store
 | **`oldpassphrase`** | <code>string</code> |
 
 **Since:** 3.0.0-beta.13
+
+--------------------
+
+
+### clearEncryptionSecret()
+
+```typescript
+clearEncryptionSecret() => Promise<void>
+```
+
+Clear the passphrase in a secure store
+
+**Since:** 3.5.1-3
 
 --------------------
 

--- a/ios/Plugin/CapacitorSQLite.swift
+++ b/ios/Plugin/CapacitorSQLite.swift
@@ -231,6 +231,32 @@ enum CapacitorSQLiteError: Error {
     // swiftlint:enable no_space_in_method_call
     // swiftlint:enable function_body_length
 
+    // MARK: - ClearEncryptionSecret
+
+    @objc public func clearEncryptionSecret() throws {
+        if isInit {
+            if isEncryption {
+                do {
+                    // close all connections
+                    try closeAllConnections()
+                    // set encryption secret
+                    try UtilsSecret
+                        .clearEncryptionSecret(prefix: prefixKeychain,
+                                               databaseLocation: databaseLocation)
+                    return
+                } catch UtilsSecretError.clearEncryptionSecret(let message) {
+                    throw CapacitorSQLiteError.failed(message: message)
+                } catch let error {
+                    throw CapacitorSQLiteError.failed(message: "\(error)")
+                }
+            } else {
+                throw CapacitorSQLiteError.failed(message: "No Encryption set in capacitor.config")
+            }
+        } else {
+            throw CapacitorSQLiteError.failed(message: initMessage)
+        }
+    }
+
     // MARK: - getNCDatabasePath
 
     @objc public func getNCDatabasePath(_ folderPath: String, dbName: String ) throws -> String {

--- a/ios/Plugin/CapacitorSQLitePlugin.m
+++ b/ios/Plugin/CapacitorSQLitePlugin.m
@@ -42,4 +42,5 @@ CAP_PLUGIN(CapacitorSQLitePlugin, "CapacitorSQLite",
            CAP_PLUGIN_METHOD(isSecretStored, CAPPluginReturnPromise);
            CAP_PLUGIN_METHOD(setEncryptionSecret, CAPPluginReturnPromise);
            CAP_PLUGIN_METHOD(changeEncryptionSecret, CAPPluginReturnPromise);
+           CAP_PLUGIN_METHOD(clearEncryptionSecret, CAPPluginReturnPromise);
 )

--- a/ios/Plugin/CapacitorSQLitePlugin.swift
+++ b/ios/Plugin/CapacitorSQLitePlugin.swift
@@ -123,6 +123,26 @@ public class CapacitorSQLitePlugin: CAPPlugin {
         }
     }
 
+    // MARK: - ClearEncryptionSecret
+
+    @objc func clearEncryptionSecret(_ call: CAPPluginCall) {
+
+        do {
+            try implementation?.clearEncryptionSecret()
+            retHandler.rResult(call: call)
+            return
+        } catch CapacitorSQLiteError.failed(let message) {
+            let msg = "ClearEncryptionSecret: \(message)"
+            retHandler.rResult(call: call, message: msg)
+            return
+        } catch let error {
+            retHandler.rResult(
+                call: call,
+                message: "ClearEncryptionSecret: \(error)")
+            return
+        }
+    }
+
     // MARK: - CreateConnection
 
     @objc func createConnection(_ call: CAPPluginCall) {

--- a/ios/Plugin/Utils/UtilsSecret.swift
+++ b/ios/Plugin/Utils/UtilsSecret.swift
@@ -13,7 +13,8 @@ enum UtilsSecretError: Error {
     case setPassphrase(message: String)
     case changePassphrase(message: String)
     case setEncryptionSecret(message: String)
-    case  changeEncryptionSecret(message: String)
+    case changeEncryptionSecret(message: String)
+    case clearEncryptionSecret(message: String)
 }
 
 let oldAccount: String = "CapacitorSQLitePlugin"
@@ -240,4 +241,22 @@ class UtilsSecret {
     }
     // swiftlint:enable function_body_length
 
+    // MARK: - ClearEncryptionSecret
+
+    class func clearEncryptionSecret(prefix: String, databaseLocation: String) throws {
+        do {
+            if prefix.isEmpty {
+                let msg: String = "keychain prefix must not be empty"
+                throw UtilsSecretError.setEncryptionSecret(message: msg)
+            }
+            // clear encrypted passphrase
+            let account = "\(prefix)_\(oldAccount)"
+            if !getPassphrase(account: account).isEmpty {
+                try setPassphrase(account: account, passphrase: "")
+            }
+        } catch UtilsSecretError.setPassphrase(let message) {
+            throw UtilsSecretError.clearEncryptionSecret(message: message)
+        }
+
+    }
 }

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -48,6 +48,13 @@ export interface CapacitorSQLitePlugin {
    * @since 3.0.0-beta.13
    */
   changeEncryptionSecret(options: capChangeSecretOptions): Promise<void>;
+  /**
+   * Clear the passphrase in the secure store
+   *
+   * @return Promise<void>
+   * @since 3.5.1-3
+   */
+  clearEncryptionSecret(): Promise<void>;
 
   /**
    * create a database connection
@@ -797,6 +804,12 @@ export interface ISQLiteConnection {
     oldpassphrase: string,
   ): Promise<void>;
   /**
+   * Clear the passphrase in a secure store
+   * @returns Promise<void>
+   * @since 3.5.1-3
+   */
+  clearEncryptionSecret(): Promise<void>;
+  /**
    * Add the upgrade Statement for database version upgrading
    * @param database
    * @param fromVersion
@@ -1036,6 +1049,14 @@ export class SQLiteConnection implements ISQLiteConnection {
         passphrase: passphrase,
         oldpassphrase: oldpassphrase,
       });
+      return Promise.resolve();
+    } catch (err) {
+      return Promise.reject(err);
+    }
+  }
+  async clearEncryptionSecret(): Promise<void> {
+    try {
+      await this.sqlite.clearEncryptionSecret();
       return Promise.resolve();
     } catch (err) {
       return Promise.reject(err);

--- a/src/web.ts
+++ b/src/web.ts
@@ -490,6 +490,11 @@ export class CapacitorSQLiteWeb
     throw this.unimplemented('Not implemented on web.');
   }
 
+  async clearEncryptionSecret(): Promise<void> {
+    console.log('clearEncryptionSecret');
+    throw this.unimplemented('Not implemented on web.');
+  }
+
   async getNCDatabasePath(
     options: capNCDatabasePathOptions,
   ): Promise<capNCDatabasePathResult> {


### PR DESCRIPTION
added a method to remove a previously stored secret in the devices keychain/sharedPreferences. this allows to recover from the situation when the old secret is unknown. without this method it is not possible to create/open a new encrypted database without knowing the previously used secret, even if it is was used for a different database or in a previous app install.