### PR TITLE
Fix #271 for iOS & added support for table name containing dash/hyphen

### DIFF
--- a/android/src/main/java/com/getcapacitor/community/database/sqlite/SQLite/ImportExportJson/UtilsJson.java
+++ b/android/src/main/java/com/getcapacitor/community/database/sqlite/SQLite/ImportExportJson/UtilsJson.java
@@ -275,7 +275,7 @@ public class UtilsJson {
         JSObject ret = new JSObject();
         ArrayList<String> names = new ArrayList<String>();
         ArrayList<String> types = new ArrayList<String>();
-        String query = new StringBuilder("PRAGMA table_info(").append(tableName).append(");").toString();
+        String query = new StringBuilder("PRAGMA table_info('").append(tableName).append("');").toString();
         try {
             JSArray resQuery = mDb.selectSQL(query, new ArrayList<Object>());
             List<JSObject> lQuery = resQuery.toList();

--- a/android/src/main/java/com/getcapacitor/community/database/sqlite/SQLite/UtilsUpgrade.java
+++ b/android/src/main/java/com/getcapacitor/community/database/sqlite/SQLite/UtilsUpgrade.java
@@ -222,7 +222,7 @@ public class UtilsUpgrade {
      */
     private List<String> getColumnNames(Database db, String table) throws Exception {
         List<String> retNames = new ArrayList<>();
-        String query = new StringBuilder("PRAGMA table_info(").append(table).append(");").toString();
+        String query = new StringBuilder("PRAGMA table_info('").append(table).append("');").toString();
         JSArray resQuery = db.selectSQL(query, new ArrayList<Object>());
         List<JSObject> lQuery = resQuery.toList();
         if (lQuery.size() > 0) {

--- a/ios/Plugin/Utils/UtilsJson.swift
+++ b/ios/Plugin/Utils/UtilsJson.swift
@@ -145,9 +145,9 @@ class UtilsJson {
     throws -> JsonNamesTypes {
         var ret: JsonNamesTypes = JsonNamesTypes(names: [], types: [])
         var msg: String = "Error: getTableColumnNamesTypes "
-        var query: String = "PRAGMA table_info("
+        var query: String = "PRAGMA table_info('"
         query.append(tableName)
-        query.append(");")
+        query.append("');")
         do {
             var resQuery =  try mDB.selectSQL(sql: query, values: [])
             if resQuery.count > 0 {

--- a/ios/Plugin/Utils/UtilsSQLCipher.swift
+++ b/ios/Plugin/Utils/UtilsSQLCipher.swift
@@ -487,7 +487,9 @@ class UtilsSQLCipher {
         var sqlStmt = sql
         do {
             let isLast: Bool = try UtilsJson.isLastModified(mDB: mDB)
-            if isLast {
+            let isDel: Bool = try UtilsJson.isSqlDeleted(mDB: mDB)
+            if isLast && isDel {
+                // Replace DELETE by UPDATE and set sql_deleted to 1
                 if let range: Range<String.Index> = sql
                     .range(of: "WHERE", options: .caseInsensitive) {
                     let index: Int = sql
@@ -514,6 +516,8 @@ class UtilsSQLCipher {
         } catch UtilsSQLCipherError.findReferenciesAndUpdate(let message) {
             throw UtilsSQLCipherError.deleteSQL(message: message)
         } catch UtilsJsonError.isLastModified(let message) {
+            throw UtilsSQLCipherError.deleteSQL(message: message)
+        } catch UtilsJsonError.isSqlDeleted(let message) {
             throw UtilsSQLCipherError.deleteSQL(message: message)
         }
     }


### PR DESCRIPTION
- Fix #271 for iOS
- Added support for table names containing character dash/hyphen (-). This fixes the issue with the TypeORM table `query-result-cache` when Caching is enabled.