### PR TITLE
Update Database.java

### DIFF
--- a/android/src/main/java/com/getcapacitor/community/database/sqlite/SQLite/Database.java
+++ b/android/src/main/java/com/getcapacitor/community/database/sqlite/SQLite/Database.java
@@ -329,7 +329,7 @@ public class Database {
                 for (String cmd : statements) {
                     if (!cmd.endsWith(";")) cmd += ";";
                     String nCmd = cmd;
-                    String trimCmd = nCmd.trim().substring(0, 11).toUpperCase();
+                    String trimCmd = nCmd.trim().substring(0, Math.min(nCmd.trim().length(), 11)).toUpperCase();
                     if (trimCmd.equals("DELETE FROM") && nCmd.toLowerCase().contains("WHERE".toLowerCase())) {
                         String whereStmt = nCmd.trim();
                         nCmd = deleteSQL(this, whereStmt, new ArrayList<Object>());


### PR DESCRIPTION
Issue introduced by this change : https://github.com/capacitor-community/sqlite/commit/98957cceacea06b77558548a3e7db808ffe049bf

The current string manipulation code here assumes a length of at least 11 characters. However I found in testing if you execute e.g. "ROLLBACK;" or "COMMIT;" (which you might do if you set the transaction option to false) then you will get an index error on this line.

e.g. java.lang.StringIndexOutOfBoundsException: length=7; index=11