### PR TITLE
Add move databases

### DIFF
--- a/README.md
+++ b/README.md
@@ -345,6 +345,7 @@ No configuration required for this plugin
 | getMigratableDbList         | ✅      | ✅  | ❌        | ❌  |
 | addSQLiteSuffix             | ✅      | ✅  | ❌        | ❌  |
 | deleteOldDatabases          | ✅      | ✅  | ❌        | ❌  |
+| moveDatabasesAndAddSuffix   | ✅      | ✅  | ❌        | ❌  |
 | checkConnectionsConsistency | ✅      | ✅  | ✅        | ✅  |
 | isSecretStored              | ✅      | ✅  | ❌        | ❌  |
 | setEncryptionSecret         | ✅      | ✅  | ❌        | ❌  |

--- a/android/src/main/java/com/getcapacitor/community/database/sqlite/CapacitorSQLite.java
+++ b/android/src/main/java/com/getcapacitor/community/database/sqlite/CapacitorSQLite.java
@@ -671,6 +671,21 @@ public class CapacitorSQLite {
     }
 
     /**
+     *
+     * @param folderPath
+     * @throws Exception
+     */
+    public void moveDatabasesAndAddSuffix(String folderPath, JSArray dbList) throws Exception {
+        try {
+            ArrayList<String> mDbList = uSqlite.stringJSArrayToArrayList(dbList);
+            uMigrate.moveDatabasesAndAddSuffix(context, folderPath, mDbList);
+            return;
+        } catch (Exception e) {
+            throw new Exception(e.getMessage());
+        }
+    }
+
+    /**
      * Execute
      * @param dbName
      * @param statements

--- a/android/src/main/java/com/getcapacitor/community/database/sqlite/CapacitorSQLitePlugin.java
+++ b/android/src/main/java/com/getcapacitor/community/database/sqlite/CapacitorSQLitePlugin.java
@@ -738,6 +738,40 @@ public class CapacitorSQLitePlugin extends Plugin {
     }
 
     /**
+     * DeleteOldDatabases Method
+     * Delete Old Cordova plugin databases
+     */
+    @PluginMethod
+    public void moveDatabasesAndAddSuffix(PluginCall call) {
+        String folderPath;
+        JSArray dbList;
+        if (!call.getData().has("folderPath")) {
+            folderPath = "default";
+        } else {
+            folderPath = call.getString("folderPath");
+        }
+        if (!call.getData().has("dbNameList")) {
+            dbList = new JSArray();
+        } else {
+            dbList = call.getArray("dbNameList");
+        }
+        if (implementation != null) {
+            try {
+                implementation.moveDatabasesAndAddSuffix(folderPath, dbList);
+                rHandler.retResult(call, null, null);
+                return;
+            } catch (Exception e) {
+                String msg = "moveDatabasesAndAddSuffix: " + e.getMessage();
+                rHandler.retResult(call, null, msg);
+                return;
+            }
+        } else {
+            rHandler.retResult(call, null, loadMessage);
+            return;
+        }
+    }
+
+    /**
      * Execute Method
      * Execute SQL statements provided in a String
      *

--- a/android/src/main/java/com/getcapacitor/community/database/sqlite/SQLite/UtilsMigrate.java
+++ b/android/src/main/java/com/getcapacitor/community/database/sqlite/SQLite/UtilsMigrate.java
@@ -124,4 +124,49 @@ public class UtilsMigrate {
         }
         return;
     }
+
+    public void moveDatabasesAndAddSuffix(Context context, String folderPath, ArrayList<String> dbList) throws Exception {
+        String pathDB = new File(context.getFilesDir().getParentFile(), "databases").getAbsolutePath();
+        File dirDB = new File(pathDB);
+        if (!dirDB.isDirectory()) {
+            dirDB.mkdir();
+        }
+        String pathFiles = this.getFolder(context, folderPath);
+        // check if the path exists
+        File dir = new File(pathFiles);
+        if (!dir.exists()) {
+            throw new Exception("Folder " + dir + " does not exist");
+        }
+        String[] listFiles = dir.list();
+        if (!pathDB.equals(pathFiles) && listFiles.length == 0) {
+            throw new Exception("Folder " + dir + " no database files");
+        }
+        for (String file : listFiles) {
+            if (file.contains("SQLite.db")) {
+                continue;
+            }
+            String fromFile = file;
+            String toFile = "";
+            if (dbList.size() > 0) {
+                if (dbList.contains(file)) {
+                    if (uFile.getFileExtension((file)).equals("db")) {
+                        toFile = file.replace(".db", "SQLite.db");
+                    } else {
+                        toFile = file.concat("SQLite.db");
+                    }
+                }
+            } else {
+                if (uFile.getFileExtension((file)).equals("db")) {
+                    toFile = file.replace(".db", "SQLite.db");
+                }
+            }
+            if (toFile.length() > 0) {
+                boolean ret = new File(pathFiles, fromFile).renameTo(new File(pathDB, toFile));
+                if (!ret) {
+                    String msg = "Failed in move " + fromFile + " to " + file;
+                    throw new Exception(msg);
+                }
+            }
+        }
+    }
 }

--- a/docs/API.md
+++ b/docs/API.md
@@ -149,6 +149,7 @@ The plugin add a suffix "SQLite" and an extension ".db" to the database name giv
 * [`getMigratableDbList(...)`](#getmigratabledblist)
 * [`addSQLiteSuffix(...)`](#addsqlitesuffix)
 * [`deleteOldDatabases(...)`](#deleteolddatabases)
+* [`moveDatabasesAndAddSuffix(...)`](#movedatabasesandaddsuffix)
 * [`checkConnectionsConsistency(...)`](#checkconnectionsconsistency)
 * [`getNCDatabasePath(...)`](#getncdatabasepath)
 * [`createNCConnection(...)`](#createncconnection)
@@ -803,6 +804,22 @@ Delete Old Cordova databases
 | **`options`** | <code><a href="#capsqlitepathoptions">capSQLitePathOptions</a></code> | : <a href="#capsqlitepathoptions">capSQLitePathOptions</a> |
 
 **Since:** 3.0.0-beta.5
+
+--------------------
+
+
+### moveDatabasesAndAddSuffix(...)
+
+```typescript
+moveDatabasesAndAddSuffix(options: capSQLitePathOptions) => Promise<void>
+```
+
+Moves databases to the location the plugin can read them, and adds sqlite suffix
+This resembles calling addSQLiteSuffix and deleteOldDatabases, but it is more performant as it doesn't copy but moves the files
+
+| Param         | Type                                                                  | Description                                                |
+| ------------- | --------------------------------------------------------------------- | ---------------------------------------------------------- |
+| **`options`** | <code><a href="#capsqlitepathoptions">capSQLitePathOptions</a></code> | : <a href="#capsqlitepathoptions">capSQLitePathOptions</a> |
 
 --------------------
 

--- a/docs/APIConnection.md
+++ b/docs/APIConnection.md
@@ -37,6 +37,7 @@
 * [`getMigratableDbList(...)`](#getmigratabledblist)
 * [`addSQLiteSuffix(...)`](#addsqlitesuffix)
 * [`deleteOldDatabases(...)`](#deleteolddatabases)
+* [`moveDatabasesAndAddSuffix(...)`](#movedatabasesandaddsuffix)
 * [Interfaces](#interfaces)
 
 </docgen-index>
@@ -557,6 +558,23 @@ Delete Old Cordova databases
 | **`dbNameList`** | <code>string[]</code> | since 3.2.4-1 |
 
 **Since:** 3.0.0-beta.5
+
+--------------------
+
+
+### moveDatabasesAndAddSuffix(...)
+
+```typescript
+moveDatabasesAndAddSuffix(folderPath?: string | undefined, dbNameList?: string[] | undefined) => Promise<void>
+```
+
+Moves databases to the location the plugin can read them, and adds sqlite suffix
+This resembles calling addSQLiteSuffix and deleteOldDatabases, but it is more performant as it doesn't copy but moves the files
+
+| Param            | Type                  | Description                                                                                                                                                       |
+| ---------------- | --------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **`folderPath`** | <code>string</code>   | the origin from where to move the databases                                                                                                                       |
+| **`dbNameList`** | <code>string[]</code> | the names of the databases to move, check out the getMigratableDbList to get a list, an empty list will result in copying all the databases with '.db' extension. |
 
 --------------------
 

--- a/ios/Plugin/CapacitorSQLite.swift
+++ b/ios/Plugin/CapacitorSQLite.swift
@@ -1341,6 +1341,32 @@ enum CapacitorSQLiteError: Error {
             throw CapacitorSQLiteError.failed(message: initMessage)
         }
     }
+
+    // MARK: - moveDatabasesAndAddSuffix
+
+    @objc func moveDatabasesAndAddSuffix(_ folderPath: String, dbList: [String]) throws {
+        if isInit {
+            do {
+                try UtilsMigrate
+                    .moveDatabasesAndAddSuffix(databaseLocation: databaseLocation,
+                                               folderPath: folderPath, 
+                                               dbList: dbList)
+                return
+            } catch UtilsMigrateError.moveDatabasesAndAddSuffix(let message) {
+                var msg: String = "moveDatabasesAndAddSuffix:"
+                msg.append(" \(message)")
+                throw CapacitorSQLiteError.failed(message: msg)
+
+            } catch let error {
+                var msg: String = "moveDatabasesAndAddSuffix:"
+                msg.append(" \(error)")
+                throw CapacitorSQLiteError.failed(message: msg)
+            }
+        } else {
+            throw CapacitorSQLiteError.failed(message: initMessage)
+        }
+    }
+
     class func getDatabaseName(dbName: String) -> String {
         var retName: String = dbName
         if !retName.contains("/") {

--- a/ios/Plugin/CapacitorSQLitePlugin.m
+++ b/ios/Plugin/CapacitorSQLitePlugin.m
@@ -38,6 +38,7 @@ CAP_PLUGIN(CapacitorSQLitePlugin, "CapacitorSQLite",
            CAP_PLUGIN_METHOD(getMigratableDbList, CAPPluginReturnPromise);
            CAP_PLUGIN_METHOD(addSQLiteSuffix, CAPPluginReturnPromise);
            CAP_PLUGIN_METHOD(deleteOldDatabases, CAPPluginReturnPromise);
+           CAP_PLUGIN_METHOD(moveDatabasesAndAddSuffix, CAPPluginReturnPromise);
            CAP_PLUGIN_METHOD(checkConnectionsConsistency, CAPPluginReturnPromise);
            CAP_PLUGIN_METHOD(isSecretStored, CAPPluginReturnPromise);
            CAP_PLUGIN_METHOD(setEncryptionSecret, CAPPluginReturnPromise);

--- a/ios/Plugin/CapacitorSQLitePlugin.swift
+++ b/ios/Plugin/CapacitorSQLitePlugin.swift
@@ -549,6 +549,35 @@ public class CapacitorSQLitePlugin: CAPPlugin {
         }
     }
 
+    // MARK: - moveDatabasesAndAddSuffix
+
+    @objc func moveDatabasesAndAddSuffix(_ call: CAPPluginCall) {
+        let folderPath: String = call.getString("folderPath") ?? "default"
+        let dbJsList: JSArray = call.getArray("dbNameList") ?? []
+        var dbList: [String] = []
+        if dbJsList.count > 0 {
+            for dbName in dbJsList {
+                if let name = dbName as? String {
+                    dbList.append(name)
+                }
+            }
+        }
+        do {
+            try implementation?.moveDatabasesAndAddSuffix(folderPath, dbList: dbList)
+            retHandler.rResult(call: call)
+            return
+        } catch CapacitorSQLiteError.failed(let message) {
+            let msg = "moveDatabasesAndAddSuffix: \(message)"
+            retHandler.rResult(call: call, message: msg)
+            return
+        } catch let error {
+            retHandler.rResult(
+                call: call,
+                message: "moveDatabasesAndAddSuffix: \(error)")
+            return
+        }
+    }
+
     // MARK: - Execute
 
     @objc func execute(_ call: CAPPluginCall) {

--- a/ios/Plugin/Utils/UtilsMigrate.swift
+++ b/ios/Plugin/Utils/UtilsMigrate.swift
@@ -238,7 +238,7 @@ class UtilsMigrate {
                         if !toFile.isEmpty {
                             let uFrom: URL = dbPathURL.appendingPathComponent(fromFile)
                             let uTo: URL = databaseURL.appendingPathComponent(toFile)
-                            try FileManager.default.moveItem(atPath: uFrom.path, toPath: uTo.path)
+                            try UtilsFile.moveFile(pathName: uFrom.path, toPathName: uTo.path, overwrite: true)
                         }
                     }
                 }

--- a/ios/Plugin/Utils/UtilsMigrate.swift
+++ b/ios/Plugin/Utils/UtilsMigrate.swift
@@ -9,6 +9,7 @@ enum UtilsMigrateError: Error {
     case addSQLiteSuffix(message: String)
     case getMigratableList(message: String)
     case deleteOldDatabases(message: String)
+    case moveDatabasesAndAddSuffix(message: String)
 }
 
 class UtilsMigrate {
@@ -187,6 +188,77 @@ class UtilsMigrate {
             var msg: String = "addSQLiteSuffix command failed :"
             msg.append(" \(error.localizedDescription)")
             throw UtilsMigrateError.addSQLiteSuffix(message: msg)
+        }
+    }
+    // swiftlint:enable cyclomatic_complexity
+    // swiftlint:enable function_body_length
+
+        // MARK: - moveDatabasesAndAddSuffix
+
+    // swiftlint:disable function_body_length
+    // swiftlint:disable cyclomatic_complexity
+    class func moveDatabasesAndAddSuffix(databaseLocation: String, folderPath: String,
+                               dbList: [String]) throws {
+        var fromFile: String = ""
+        var toFile: String = ""
+        do {
+            let databaseURL: URL = try UtilsFile
+                .getFolderURL(folderPath: databaseLocation)
+            let dbPathURL: URL = try UtilsFile
+                .getFolderURL(folderPath: folderPath)
+            var isDir = ObjCBool(true)
+            if FileManager.default.fileExists(atPath: dbPathURL.relativePath,
+                                              isDirectory: &isDir) &&
+                isDir.boolValue {
+                var mDbList: [String]
+                if dbList.count > 0 {
+                    mDbList = try UtilsFile
+                        .getFileList(path: dbPathURL.relativePath, ext: nil)
+                } else {
+                    mDbList = try UtilsFile
+                        .getFileList(path: dbPathURL.relativePath, ext: "db")
+                }
+                for file: String in mDbList {
+                    if !file.contains("SQLite.db") {
+                        fromFile = file
+                        toFile = "";
+                        if dbList.count > 0 {
+                            if dbList.contains(fromFile) {
+                                if String(file.suffix(3)) == ".db" {
+                                    toFile = file
+                                        .replacingOccurrences(of: ".db", with: "SQLite.db")
+                                } else {
+                                    toFile = file + "SQLite.db"
+                                }
+                            }
+                        } else {
+                            toFile = file
+                                .replacingOccurrences(of: ".db", with: "SQLite.db")
+                        }
+                        if !toFile.isEmpty {
+                            let uFrom: URL = dbPathURL.appendingPathComponent(fromFile)
+                            let uTo: URL = databaseURL.appendingPathComponent(toFile)
+                            try FileManager.default.moveItem(atPath: uFrom.path, toPath: uTo.path)
+                        }
+                    }
+                }
+                return
+            } else {
+                var msg: String = "moveDatabasesAndAddSuffix command failed :"
+                msg.append(" Folder '\(dbPathURL.absoluteString)' not found")
+                throw UtilsMigrateError.moveDatabasesAndAddSuffix(message: msg)
+            }
+        } catch UtilsFileError.getDatabasesURLFailed {
+            throw UtilsMigrateError
+            .moveDatabasesAndAddSuffix(message: "getDatabasesURLFailed")
+        } catch UtilsFileError.getFolderURLFailed(let message) {
+            throw UtilsMigrateError.moveDatabasesAndAddSuffix(message: message)
+        } catch UtilsFileError.getFileListFailed {
+            throw UtilsMigrateError.moveDatabasesAndAddSuffix(message: "getFileListFailed")
+        } catch let error {
+            var msg: String = "moveDatabasesAndAddSuffix command failed :"
+            msg.append(" \(error.localizedDescription)")
+            throw UtilsMigrateError.moveDatabasesAndAddSuffix(message: msg)
         }
     }
     // swiftlint:enable cyclomatic_complexity

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -269,6 +269,12 @@ export interface CapacitorSQLitePlugin {
    */
   deleteOldDatabases(options: capSQLitePathOptions): Promise<void>;
   /**
+   * Moves databases to the location the plugin can read them, and adds sqlite suffix
+   * This resembles calling addSQLiteSuffix and deleteOldDatabases, but it is more performant as it doesn't copy but moves the files
+   * @param options: capSQLitePathOptions
+   */
+  moveDatabasesAndAddSuffix(options: capSQLitePathOptions): Promise<void>;
+  /**
    * Check Connection Consistency JS <=> Native
    * return true : consistency, connections are opened
    * return false : no consistency, connections are closed
@@ -991,6 +997,13 @@ export interface ISQLiteConnection {
    * @since 3.0.0-beta.5
    */
   deleteOldDatabases(folderPath?: string, dbNameList?: string[]): Promise<void>;
+  /**
+   * Moves databases to the location the plugin can read them, and adds sqlite suffix
+   * This resembles calling addSQLiteSuffix and deleteOldDatabases, but it is more performant as it doesn't copy but moves the files
+   * @param folderPath the origin from where to move the databases
+   * @param dbNameList the names of the databases to move, check out the getMigratableDbList to get a list, an empty list will result in copying all the databases with '.db' extension.
+   */
+  moveDatabasesAndAddSuffix(folderPath?: string, dbNameList?: string[]): Promise<void>;
 }
 /**
  * SQLiteConnection Class
@@ -1321,6 +1334,17 @@ export class SQLiteConnection implements ISQLiteConnection {
     } catch (err) {
       return Promise.reject(err);
     }
+  }
+
+  async moveDatabasesAndAddSuffix(folderPath?: string,
+    dbNameList?: string[],
+  ): Promise<void> {
+    const path: string = folderPath ? folderPath : 'default';
+    const dbList: string[] = dbNameList ? dbNameList : [];
+    return this.sqlite.moveDatabasesAndAddSuffix({
+      folderPath: path,
+      dbNameList: dbList,
+    });
   }
 }
 

--- a/src/web.ts
+++ b/src/web.ts
@@ -476,6 +476,11 @@ export class CapacitorSQLiteWeb
     throw this.unimplemented('Not implemented on web.');
   }
 
+  async moveDatabasesAndAddSuffix(options: capSQLitePathOptions): Promise<void> {
+    console.log('moveDatabasesAndAddSuffix', options);
+    throw this.unimplemented('Not implemented on web.');
+  }
+
   async isSecretStored(): Promise<capSQLiteResult> {
     throw this.unimplemented('Not implemented on web.');
   }


### PR DESCRIPTION
Fixes #302
This operation allows to move a database instead of copy and then delete.
I still need to test this on iOS, but on android it looks like it's working.
Please let me know what else I need to change in general, as it won't change much in terms of code I believe.



Also, I wanted to add a test to the ionic angular but I think this needs the filesystem capacitor plugin and I'm not sure this dependency is OK, so I wanted to run it by you first...