### PR TITLE
Add info related to #301

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,6 +315,14 @@ npx cap open ios
 ```
 npx cap open android
 ```
+In case you get the following error:
+`x files found with path 'build-data.properties'.`
+You can you add the following code to `app/build.gradle`:
+```
+    packagingOptions {
+        exclude 'build-data.properties'
+    }
+```
 
 ### Electron
 

--- a/README.md
+++ b/README.md
@@ -323,6 +323,7 @@ You can you add the following code to `app/build.gradle`:
         exclude 'build-data.properties'
     }
 ```
+See [#301](https://github.com/capacitor-community/sqlite/issues/301) and [SO](https://stackoverflow.com/questions/63291529/how-to-fix-more-than-one-file-was-found-with-os-independent-path-build-data-pro] for more information.
 
 ### Electron
 


### PR DESCRIPTION
I've added the relevant data.
As a side not, I would consider removing all the info with all the versions and place this info in the changelog file or a migration.md file in case the instruction are related to how to upgrade from version to version.
Also the red icons looks like bugs or some kind of error so I would consider avoiding them too.
Another thing that can be improved is to place all the information about installation build and run for every platform in the same place instead of splitting the installation and build & run to separate paragraphs - this way you have all the information about a platform in the same place.
If this is something you would like me to open a PR for let me know. I think the readme should be a lot more cleaner...