### PR TITLE
Fixes #320

### DIFF
--- a/android/src/main/java/com/getcapacitor/community/database/sqlite/CapacitorSQLitePlugin.java
+++ b/android/src/main/java/com/getcapacitor/community/database/sqlite/CapacitorSQLitePlugin.java
@@ -12,8 +12,12 @@ import com.getcapacitor.annotation.CapacitorPlugin;
 import com.getcapacitor.community.database.sqlite.SQLite.Database;
 import com.getcapacitor.community.database.sqlite.SQLite.ImportExportJson.JsonSQLite;
 import com.getcapacitor.community.database.sqlite.SQLite.SqliteConfig;
+
+import java.util.Collections;
 import java.util.Dictionary;
 import java.util.Hashtable;
+import java.util.List;
+
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -1220,7 +1224,18 @@ public class CapacitorSQLitePlugin extends Plugin {
         if (implementation != null) {
             try {
                 Dictionary<Integer, JSONObject> upgDict = implementation.addUpgradeStatement(upgrade);
-                versionUpgrades.put(dbName, upgDict);
+
+                if (versionUpgrades.get(dbName) != null){
+                    List<Integer> keys = Collections.list(upgDict.keys());
+                        for (Integer versionKey : keys) {
+                        JSONObject upgObj = upgDict.get(versionKey);
+
+                        versionUpgrades.get(dbName).put(versionKey, upgObj);
+                    }
+                } else {
+                    versionUpgrades.put(dbName, upgDict);
+                }
+
                 rHandler.retResult(call, null, null);
                 return;
             } catch (Exception e) {

--- a/android/src/main/java/com/getcapacitor/community/database/sqlite/SQLite/UtilsUpgrade.java
+++ b/android/src/main/java/com/getcapacitor/community/database/sqlite/SQLite/UtilsUpgrade.java
@@ -25,13 +25,14 @@ public class UtilsUpgrade {
      */
     public void onUpgrade(Database db, Dictionary<Integer, JSONObject> upgDict, Integer curVersion, Integer targetVersion)
         throws Exception {
-        Log.i(TAG, "UtilsUpgrade.onUpgrade: " + curVersion + " => " + targetVersion);
+        Log.i(TAG, "UtilsUpgrade.onUpgrade: from " + curVersion + " to " + targetVersion);
 
         List<Integer> sortedKeys = Collections.list(upgDict.keys());
         Collections.sort(sortedKeys);
 
         for (Integer versionKey : sortedKeys) {
             if (versionKey > curVersion && versionKey <= targetVersion) {
+                Log.i(TAG, "- UtilsUpgrade.onUpgrade toVersion: " + versionKey);
                 JSONObject upgrade = upgDict.get(versionKey);
 
                 JSONArray statementsJson = upgrade.has("statements") ? upgrade.getJSONArray("statements") : new JSONArray();

--- a/electron/src/electron-utils/utilsUpgrade.ts
+++ b/electron/src/electron-utils/utilsUpgrade.ts
@@ -19,6 +19,7 @@ export class UtilsUpgrade {
     curVersion: number,
     targetVersion: number,
   ): Promise<number> {
+    let changes;
     const sortedKeys: number[] = Object.keys(vUpgDict)
       .map(item => parseInt(item))
       .sort();
@@ -39,13 +40,14 @@ export class UtilsUpgrade {
           await this.sqliteUtil.setVersion(mDB, versionKey);
           // set Foreign Keys On
           await this.sqliteUtil.setForeignKeyConstraintsEnabled(mDB, true);
-          const changes = (await this.sqliteUtil.dbChanges(mDB)) - initChanges;
-          return Promise.resolve(changes);
+          changes = (await this.sqliteUtil.dbChanges(mDB)) - initChanges;
         } catch (err) {
           return Promise.reject(`onUpgrade: ${err}`);
         }
       }
     }
+
+    return Promise.resolve(changes);
   }
   /**
    * ExecuteStatementProcess

--- a/electron/src/index.ts
+++ b/electron/src/index.ts
@@ -646,9 +646,14 @@ export class CapacitorSQLite implements CapacitorSQLitePlugin {
       throw new Error('upgrade.toVersion must be a number');
     }
 
-    const upgradeVersionDict: Record<number, capSQLiteVersionUpgrade> = {};
-    upgradeVersionDict[firstUpgrade.toVersion] = firstUpgrade;
-    this.versionUpgrades[dbName] = upgradeVersionDict;
+    if (this.versionUpgrades[dbName]) {
+      this.versionUpgrades[dbName][firstUpgrade.toVersion] = firstUpgrade;
+    } else {
+      const upgradeVersionDict: Record<number, capSQLiteVersionUpgrade> = {};
+      upgradeVersionDict[firstUpgrade.toVersion] = firstUpgrade;
+      this.versionUpgrades[dbName] = upgradeVersionDict;
+    }
+
     return;
   }
 

--- a/ios/Plugin/CapacitorSQLitePlugin.swift
+++ b/ios/Plugin/CapacitorSQLitePlugin.swift
@@ -1158,7 +1158,16 @@ public class CapacitorSQLitePlugin: CAPPlugin {
             if let upgVersionDict: [Int: [String: Any]] = try
                 implementation?.addUpgradeStatement(dbName,
                                                     upgrade: upgrade) {
-                versionUpgrades = ["\(dbName)": upgVersionDict]
+                if (
+                    versionUpgrades[dbName] != nil
+                ){
+                    for (versionKey, upgObj) in upgVersionDict {
+                        versionUpgrades[dbName]![versionKey] = upgObj
+                    }
+                } else {
+                    versionUpgrades = ["\(dbName)": upgVersionDict]
+                }
+
                 retHandler.rResult(call: call)
                 return
             } else {

--- a/ios/Plugin/Utils/UtilsUpgrade.swift
+++ b/ios/Plugin/Utils/UtilsUpgrade.swift
@@ -22,10 +22,12 @@ class UtilsUpgrade {
                    currentVersion: Int,
                    targetVersion: Int,
                    databaseLocation: String) throws {
-        print("UtilsUpgrade.onUpgrade: \(currentVersion) => \(targetVersion)")
+        print("UtilsUpgrade.onUpgrade: from \(currentVersion) to \(targetVersion)")
 
         for (versionKey, upgrade) in Array(upgDict).sorted(by: {$0.0 < $1.0}) {
             if versionKey > currentVersion && versionKey <= targetVersion {
+                print("- UtilsUpgrade.onUpgrade toVersion: \(versionKey)")
+                
                 guard let statements = upgrade["statements"] as? [String] else {
                     let msg: String = "Error: onUpgrade statements not given"
                     throw UtilsUpgradeError.onUpgradeFailed(message: msg)


### PR DESCRIPTION
Fixes #320

The `addUpgradeStatement()` method overwrites previous updates. This PR allows to add several upgrades without overwriting the existing ones (as expected).