### PR TITLE
Fix electron db.close() error reporting

### DIFF
--- a/electron/src/electron-utils/Database.ts
+++ b/electron/src/electron-utils/Database.ts
@@ -145,7 +145,7 @@ export class Database {
 
     this.database.close((err: Error) => {
       if (err) {
-        throw new Error('Close failed: ${this.dbName}  ${err}');
+        throw new Error(`Close failed: ${this.dbName}  ${err}`);
       }
       this._isDbOpen = false;
     });


### PR DESCRIPTION
prior to this commit, the error message wasn't shown correctly