### PR TITLE
Fix windows file lock error #326

### DIFF
--- a/electron/src/electron-utils/Database.ts
+++ b/electron/src/electron-utils/Database.ts
@@ -145,7 +145,7 @@ export class Database {
 
     this.database.close((err: Error) => {
       if (err) {
-        throw new Error('Close failed: ${this.dbName}  ${err}');
+        throw new Error(`Close failed: ${this.dbName}  ${err}`);
       }
       this._isDbOpen = false;
     });

--- a/electron/src/electron-utils/Database.ts
+++ b/electron/src/electron-utils/Database.ts
@@ -143,12 +143,18 @@ export class Database {
   async close(): Promise<void> {
     this.ensureDatabaseIsOpen();
 
-    this.database.close((err: Error) => {
-      if (err) {
-        throw new Error(`Close failed: ${this.dbName}  ${err}`);
-      }
-      this._isDbOpen = false;
+    return new Promise((resolve, reject) => {
+      this.database.close((err: Error) => {
+        if (err) {
+          reject(new Error(`Close failed: ${this.dbName}  ${err}`));
+          return;
+        }
+
+        this._isDbOpen = false;
+        resolve();
+      });
     });
+
   }
 
   /**

--- a/electron/src/electron-utils/Database.ts
+++ b/electron/src/electron-utils/Database.ts
@@ -1,7 +1,7 @@
 //import { GlobalSQLite } from '../GlobalSQLite';
 import type {
   capSQLiteVersionUpgrade,
-  JsonSQLite,
+  JsonSQLite
 } from '../../../src/definitions';
 
 import { ExportToJson } from './ImportExportJson/exportToJson';


### PR DESCRIPTION
fixes issue #326 

The main issue was a race condition. The `db.close()` method resolved BEFORE the db file was released.


![](https://user-images.githubusercontent.com/1294854/194747248-0cde6376-4710-45df-ad55-d2475b988ed5.png)


Additionally I implemented a file-lock check, which waits up to 4 seconds in case the file is still locked.

