### PR TITLE
Warning readme node-fetch version in electron

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ npm install --save jszip
 npm install --save node-fetch
 npm install --save-dev @types/sqlite3
 ```
+- **Important**: `node-fetch` version must be `<=2.6.7`; otherwise [you'll get an error](https://github.com/capacitor-community/sqlite/issues/349 "you'll get an error ERR_REQUIRE_ESM") running the app. 
 
 ## IOS Quirks
 


### PR DESCRIPTION
Added in Electron Quirks section a warning of node-fetch version necessary to solve the ERR_REQUIRE_ESM error in version >3