### PR TITLE
Fixes `createNCConnection` and `closeNCConnection` in Android. Closes #356

### DIFF
--- a/android/src/main/java/com/getcapacitor/community/database/sqlite/CapacitorSQLite.java
+++ b/android/src/main/java/com/getcapacitor/community/database/sqlite/CapacitorSQLite.java
@@ -496,7 +496,7 @@ public class CapacitorSQLite {
      */
     public void closeNCConnection(String dbPath) throws Exception {
         String connName = "RO_" + dbPath;
-        Database db = dbDict.get(dbPath);
+        Database db = dbDict.get(connName);
         if (db != null) {
             if (db.isOpen()) {
                 try {

--- a/android/src/main/java/com/getcapacitor/community/database/sqlite/CapacitorSQLite.java
+++ b/android/src/main/java/com/getcapacitor/community/database/sqlite/CapacitorSQLite.java
@@ -373,7 +373,7 @@ public class CapacitorSQLite {
                 true
             );
             if (db != null) {
-                dbDict.put(dbPath, db);
+                dbDict.put(connName, db);
                 return;
             } else {
                 String msg = "db is null";


### PR DESCRIPTION
The functions  `createNCConnection` and `closeNCConnection` were not prepending 'RO_' when searching in internal dbDict, so the connections were not found when opened or closed.

 Closes #356