### PR TITLE
fix(docs): use `yarn add` in favor of deprecated `yarn install --save`

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ npx cap sync
 ```
 
 ```
-yarn install --save @capacitor-community/sqlite
+yarn add @capacitor-community/sqlite
 npx cap sync
 ```
 


### PR DESCRIPTION
The installation command for yarn is using a deprecated command and doesn't work at the moment.

`yarn install --save PACKAGE` is deprecated in favor of `yarn add PACKAGE`. `yarn install` is now used to install a project's dependencies.

Docs: https://classic.yarnpkg.com/lang/en/docs/cli/install/