### PR TITLE
Fix file deletion for windows

### DIFF
--- a/electron/src/electron-utils/utilsFile.ts
+++ b/electron/src/electron-utils/utilsFile.ts
@@ -1,4 +1,4 @@
-import { open } from 'node:fs/promises';
+import { open, unlink } from 'node:fs/promises';
 
 export class UtilsFile {
   pathDB = 'Databases';
@@ -344,17 +344,40 @@ export class UtilsFile {
    * @param filePath
    */
   public async deleteFilePath(filePath: string): Promise<void> {
+
+    let unlinkRetries = 50000;
+
+    /**
+     * On windows, the file lock behaves unpredictable. Often it claims a databsae file is locked / busy, although
+     * the file stream is already closed.
+     * Even though we already checked the status with the `waitForFilePathLock()` method previously.
+     * 
+     * The only way to handle this reliably is to retry deletion until it works.
+     */
+    const deleteFile = async () => {
+      try {
+        await unlink(filePath);
+      } catch (err) {
+        unlinkRetries--;
+        if (unlinkRetries > 0) {
+          await deleteFile();
+        } else {
+          throw err;
+        }
+      }
+    }
+
     if (filePath.length !== 0) {
       // check if path exists
       const isPath = this.isPathExists(filePath);
       if (isPath) {
         try {
           await this.waitForFilePathLock(filePath);
-
-          this.NodeFs.unlinkSync(filePath);
+          // actually delete the file
+          await deleteFile();
           return Promise.resolve();
         } catch (err) {
-          return Promise.reject('DeleteFilePath: ' + `${err}`);
+          return Promise.reject(`DeleteFilePath: ${err}`);
         }
       } else {
         return Promise.resolve();


### PR DESCRIPTION
retry deletion until it worked (or retry at up to 50,000 times, and then throw an error)

closes issue #366 