### PR TITLE
Strip comment lines when using CapacitorSQLite.execute on Android

### DIFF
--- a/android/src/main/java/com/getcapacitor/community/database/sqlite/SQLite/UtilsSQLite.java
+++ b/android/src/main/java/com/getcapacitor/community/database/sqlite/SQLite/UtilsSQLite.java
@@ -63,7 +63,16 @@ public class UtilsSQLite {
             String[] array = sqlCmdArray[i].split("\n");
             StringBuilder builder = new StringBuilder();
             for (String s : array) {
-                builder.append(" ").append(s.trim());
+                String line = s.trim();
+                if (line.startsWith("--")) {
+                    // is a comment, do nothing
+                } else if (s.length() > 0) {
+                    if (builder.length() > 0) {
+                        builder.append(" ");
+                    }
+                    builder.append(s);
+                }
+
             }
             sqlCmdArray[i] = builder.toString();
         }

--- a/android/src/test/java/com/getcapacitor/ExampleUnitTest.java
+++ b/android/src/test/java/com/getcapacitor/ExampleUnitTest.java
@@ -1,6 +1,9 @@
 package com.getcapacitor;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+
+import com.getcapacitor.community.database.sqlite.SQLite.UtilsSQLite;
 
 import org.junit.Test;
 
@@ -11,8 +14,60 @@ import org.junit.Test;
  */
 public class ExampleUnitTest {
 
+    private final UtilsSQLite uSqlite = new UtilsSQLite();
+
     @Test
     public void addition_isCorrect() throws Exception {
         assertEquals(4, 2 + 2);
+    }
+
+    @Test
+    public void getStatementsArray_canHandleComments() throws Exception {
+        String[] actualLines = {
+            "-- RedefineTables",
+            "PRAGMA foreign_keys = OFF;",
+            "",
+            "-- CreateTable",
+            "CREATE TABLE IF NOT EXISTS key_value (key TEXT NOT NULL PRIMARY KEY, VALUE TEXT);",
+        };
+
+        String[] expected = {
+            "PRAGMA foreign_keys = OFF",
+            "CREATE TABLE IF NOT EXISTS key_value (key TEXT NOT NULL PRIMARY KEY, VALUE TEXT);"
+        };
+
+        assertArrayEquals(
+            expected,
+            uSqlite.getStatementsArray(
+                String.join("\n", actualLines)
+            ));
+    }
+
+    @Test
+    public void getStatementsArray_canHandleWhitespace() throws Exception {
+        String[] actualLines = {
+            "-- RedefineTables",
+            "",
+            "PRAGMA foreign_keys = OFF;",
+            "",
+            "-- CreateTable",
+            "CREATE TABLE",
+            "IF NOT EXISTS key_value",
+            "--comment in the middle",
+            "",
+            "(key TEXT NOT NULL PRIMARY KEY, VALUE TEXT);",
+            ""
+        };
+
+        String[] expected = {
+            "PRAGMA foreign_keys = OFF",
+            "CREATE TABLE IF NOT EXISTS key_value (key TEXT NOT NULL PRIMARY KEY, VALUE TEXT)"
+        };
+
+        assertArrayEquals(
+            expected,
+            uSqlite.getStatementsArray(
+                String.join("\n", actualLines)
+            ));
     }
 }


### PR DESCRIPTION
### Purpose

Fixes #386 

This PR makes getStatementsArray on Android ignore any line that starts with "--", which is most likely indicating a comment. In turn, this avoids an error where a comment line is squashed with a statement lines and cancels out the real statements.

### Caveats

While it is also possible to write sql with multiline comments and "--" comments in the same line, this would require much more advance parsing to avoid breaking valid sql using `--` or `/*` inside of literals. I think that would be too risky and not worth it.

```sql
SELECT "hello"; --comment
SELECT "hello" /* comment */;
SELECT "hello --not a comment";
SELECT "hello /* not a comment */";
```

Also, I discovered that sqlite supports multiline strings:

```sql
SELECT 'hello
--not a comment
';
```

This line would be incorrectly mangled into `SELECT 'hello ';` with this PR. However, even in the master branch, it would be incorrectly transformed to `SELECT 'hello --not a comment '`;. Both the master branch and this PR are not supporting multiline string, so the support of multiline string would not change.

### Testing

I put some unit tests in `android/src/test/java/com/getcapacitor/ExampleUnitTest.java` file. These tests can be run with `npm run verify` or `npm run verify:android`

I also tried the modification in a real project and it could run the sql script on Android with the comments included.