### PR TITLE
fix(android): Fix parsing of statement type from SQL statement

### DIFF
--- a/android/src/main/java/com/getcapacitor/community/database/sqlite/SQLite/Database.java
+++ b/android/src/main/java/com/getcapacitor/community/database/sqlite/SQLite/Database.java
@@ -636,7 +636,7 @@ public class Database {
      * @throws Exception message
      */
     public JSObject prepareSQL(String statement, ArrayList<Object> values, Boolean fromJson, String returnMode) throws Exception {
-        String stmtType = statement.replaceAll("\n", "").trim().substring(0, 6).toUpperCase();
+        String stmtType = statement.replaceAll("\n", "\s").trim().split("\s")[0].toUpperCase();
         SupportSQLiteStatement stmt = null;
         String sqlStmt = statement;
         String retMode;


### PR DESCRIPTION
Currently this fails when running statements with commands shorter than 6 characters like `BEGIN`.

Fixes https://github.com/capacitor-community/sqlite/issues/526