### PR TITLE
Update TypeORM-Usage-From-5.6.0.md

### DIFF
--- a/docs/TypeORM-Usage-From-5.6.0.md
+++ b/docs/TypeORM-Usage-From-5.6.0.md
@@ -211,95 +211,99 @@ const fs = require('fs');
 // For ESModule:
 // import fs from 'fs';
 
-
 /* Modify CapacitorQueryRunner.js */
 const correctBugInCapacitorQueryRunner = (file) => {
-    if (fs.existsSync(file)) {
-        fs.readFile(file, 'utf8', function (err, data) {
-            if (err) {
-                return console.error(err);
-            }
+  if (fs.existsSync(file)) {
+    fs.readFile(file, 'utf8', function (err, data) {
+      if (err) {
+        return console.error(err);
+      }
 
-            // This key helps to identify that this file has been modified by this script
-            const isModifiedKey = "/** correctBugInCapacitorQueryRunner */";
-            const isModifiedIndex = data.indexOf(isModifiedKey);
+      // This key helps to identify that this file has been modified by this script
+      const isModifiedKey = "/** correctBugInCapacitorQueryRunner */";
+      const isModifiedIndex = data.indexOf(isModifiedKey);
 
-            if (isModifiedIndex !== -1) {
-                console.warn(`${isModifiedKey} found. Package probably fixed.`);
-                return;
-            }
+      if (isModifiedIndex !== -1) {
+        console.warn(`${isModifiedKey} found. Package probably fixed.`);
+        return;
+      }
 
-            const index = data.indexOf(`"DROP",`)
-            if (index === -1) {
-                console.warn('Line not found. Package probably fixed.');
-                return;
-            }
+      const index = data.indexOf(`"DROP",`)
+      if (index === -1) {
+        console.warn('Line not found. Package probably fixed.');
+        return;
+      }
 
-            var result = data.replace(
-                `    "DROP",`,
-                `    "DROP",
-              	"PRAGMA"`
+      var result = data.replace(
+        `    "DROP",`,
+        `    "DROP",
+        "PRAGMA"`
 
-            );
-            result = result.replace(
-                'else if (["INSERT", "UPDATE", "DELETE", "PRAGMA"].indexOf(command) !== -1) {',
-                'else if (["INSERT", "UPDATE", "DELETE"].indexOf(command) !== -1) {'
-            );
+      );
+      result = result.replace(
+        'else if (["INSERT", "UPDATE", "DELETE", "PRAGMA"].indexOf(command) !== -1) {',
+        'else if (["INSERT", "UPDATE", "DELETE"].indexOf(command) !== -1) {'
+      );
 
-            result += isModifiedKey;
+      result += isModifiedKey;
 
-            fs.writeFile(file, result, 'utf8', function (err) {
-                if (err) return console.error(err);
-            });
-        });
-    } else {
-        utils.warn(`Couldn't find file ${file}`);
-    }
+      fs.writeFile(file, result, 'utf8', function (err) {
+        if (err) return console.error(err);
+      });
+    });
+  } else {
+    utils.warn(`Couldn't find file ${file}`);
+  }
 
 }
 /* Moddify CapacitorDriver.js */
 const correctBugInCapacitorDriver = (file) => {
-    if (fs.existsSync(file)) {
-        fs.readFile(file, 'utf8', function (err, data) {
-            if (err) {
-                return console.error(err);
-            }
+  if (fs.existsSync(file)) {
+    fs.readFile(file, 'utf8', function (err, data) {
+      if (err) {
+        return console.error(err);
+      }
 
-            // This key helps to identify that this file has been modified by this script
-            const isModifiedKey = "/** correctBugInCapacitorDriver */";
-            const isModifiedIndex = data.indexOf(isModifiedKey);
+      // This key helps to identify that this file has been modified by this script
+      const isModifiedKey = "/** correctBugInCapacitorDriver */";
+      const isModifiedIndex = data.indexOf(isModifiedKey);
 
-            if (isModifiedIndex !== -1) {
-                console.warn(`${isModifiedKey} found. Package probably fixed.`);
-                return;
-            }
+      if (isModifiedIndex !== -1) {
+        console.warn(`${isModifiedKey} found. Package probably fixed.`);
+        return;
+      }
 
-            const index = data.indexOf('await connection.run(`PRAGMA foreign_keys = ON`);');
-            if (index === -1) {
-                console.warn('Line not found. Package probably fixed.');
-                return;
-            }
+      const index = data.indexOf('await connection.run(`PRAGMA foreign_keys = ON`);');
+      if (index === -1) {
+        console.warn('Line not found. Package probably fixed.');
+        return;
+      }
 
-            var result = data.replace(
-                'await connection.run(`PRAGMA foreign_keys = ON`);',
-                'await connection.execute(`PRAGMA foreign_keys = ON`, false);'
-            );
+      var result = data.replace(
+        'await connection.run(`PRAGMA foreign_keys = ON`);',
+        'await connection.execute(`PRAGMA foreign_keys = ON`, false);'
+      );
 
-            result = result.replace(
-                'await connection.run(`PRAGMA journal_mode = ${this.options.journalMode}`);',
-                'await connection.execute(`PRAGMA journal_mode = ${this.options.journalMode}`, false);'
-            );
+      result = result.replace(
+        'await connection.run(`PRAGMA journal_mode = ${this.options.journalMode}`);',
+        'await connection.execute(`PRAGMA journal_mode = ${this.options.journalMode}`, false);'
+      );
 
-            result += isModifiedKey;
+      result += isModifiedKey;
 
-            fs.writeFile(file, result, 'utf8', function (err) {
-                if (err) return console.error(err);
-            });
-        });
-    } else {
-        utils.warn(`Couldn't find file ${file}`);
-    }
+      fs.writeFile(file, result, 'utf8', function (err) {
+        if (err) return console.error(err);
+      });
+    });
+  } else {
+    utils.warn(`Couldn't find file ${file}`);
+  }
 }
+
+correctBugInCapacitorQueryRunner('./node_modules/typeorm/driver/capacitor/CapacitorQueryRunner.js');
+correctBugInCapacitorQueryRunner('./node_modules/typeorm/browser/driver/capacitor/CapacitorQueryRunner.js');
+correctBugInCapacitorDriver('./node_modules/typeorm/driver/capacitor/CapacitorDriver.js');
+correctBugInCapacitorDriver('./node_modules/typeorm/browser/driver/capacitor/CapacitorDriver.js');
  ```
 
  - In your `package.json` add `"postinstall": "node ./scripts/modify-typeorm.cjs"` or for ESModule: `"postinstall": "npx tsx ./scripts/modify-typeorm.js"`

--- a/docs/TypeORM-Usage-From-5.6.0.md
+++ b/docs/TypeORM-Usage-From-5.6.0.md
@@ -204,82 +204,105 @@ export const getCountOfElements =  (async (connection: DataSource, entity:any): 
 
  - create a `scripts` directory at the root of the App.
 
- - create a `modify-typeorm.cjs` file under this directory with:
+ - create a `modify-typeorm.cjs`/`modify-typeorm.js (for ESModule)` file under this directory with:
 
  ```js
 const fs = require('fs');
+// For ESModule:
+// import fs from 'fs';
 
-/* Moddify CapacitorQueryRunner.js */
+
+/* Modify CapacitorQueryRunner.js */
 const correctBugInCapacitorQueryRunner = (file) => {
-  if (fs.existsSync(file)) {
-    fs.readFile(file, 'utf8', function (err, data) {
-        if (err) {
-            return console.error(err);
-        }
+    if (fs.existsSync(file)) {
+        fs.readFile(file, 'utf8', function (err, data) {
+            if (err) {
+                return console.error(err);
+            }
 
-        const index = `"DROP",`
-        if (index === -1) {
-            console.warn('Line not found. Package probably fixed.');
-            return;
-        }
+            // This key helps to identify that this file has been modified by this script
+            const isModifiedKey = "/** correctBugInCapacitorQueryRunner */";
+            const isModifiedIndex = data.indexOf(isModifiedKey);
 
-        var result = data.replace(
-          `    "DROP",`,
-          `    "DROP",
-               "PRAGMA"`
+            if (isModifiedIndex !== -1) {
+                console.warn(`${isModifiedKey} found. Package probably fixed.`);
+                return;
+            }
 
-        );
-        result = result.replace(
-            'else if (["INSERT", "UPDATE", "DELETE", "PRAGMA"].indexOf(command) !== -1) {',
-            'else if (["INSERT", "UPDATE", "DELETE"].indexOf(command) !== -1) {'
-        );
+            const index = data.indexOf(`"DROP",`)
+            if (index === -1) {
+                console.warn('Line not found. Package probably fixed.');
+                return;
+            }
 
-        fs.writeFile(file, result, 'utf8', function (err) {
-            if (err) return console.error(err);
+            var result = data.replace(
+                `    "DROP",`,
+                `    "DROP",
+              	"PRAGMA"`
+
+            );
+            result = result.replace(
+                'else if (["INSERT", "UPDATE", "DELETE", "PRAGMA"].indexOf(command) !== -1) {',
+                'else if (["INSERT", "UPDATE", "DELETE"].indexOf(command) !== -1) {'
+            );
+
+            result += isModifiedKey;
+
+            fs.writeFile(file, result, 'utf8', function (err) {
+                if (err) return console.error(err);
+            });
         });
-    });
-  } else {
-      utils.warn(`Couldn't find file ${file}`);
-  }
+    } else {
+        utils.warn(`Couldn't find file ${file}`);
+    }
 
 }
 /* Moddify CapacitorDriver.js */
 const correctBugInCapacitorDriver = (file) => {
-  if (fs.existsSync(file)) {
-      fs.readFile(file, 'utf8', function (err, data) {
-          if (err) {
-              return console.error(err);
-          }
+    if (fs.existsSync(file)) {
+        fs.readFile(file, 'utf8', function (err, data) {
+            if (err) {
+                return console.error(err);
+            }
 
-          const index = data.indexOf('await connection.run(`PRAGMA foreign_keys = ON`);');
-          if (index === -1) {
-              console.warn('Line not found. Package probably fixed.');
-              return;
-          }
+            // This key helps to identify that this file has been modified by this script
+            const isModifiedKey = "/** correctBugInCapacitorDriver */";
+            const isModifiedIndex = data.indexOf(isModifiedKey);
 
-          var result = data.replace(
-              'await connection.run(`PRAGMA foreign_keys = ON`);',
-              'await connection.execute(`PRAGMA foreign_keys = ON`, false);'
-          );
-          result = result.replace(
-              'await connection.run(`PRAGMA journal_mode = ${this.options.journalMode}`);',
-              'await connection.execute(`PRAGMA journal_mode = ${this.options.journalMode}`, false);'
-          );
+            if (isModifiedIndex !== -1) {
+                console.warn(`${isModifiedKey} found. Package probably fixed.`);
+                return;
+            }
 
-          fs.writeFile(file, result, 'utf8', function (err) {
-              if (err) return console.error(err);
-          });
-      });
-  } else {
-      utils.warn(`Couldn't find file ${file}`);
-  }
+            const index = data.indexOf('await connection.run(`PRAGMA foreign_keys = ON`);');
+            if (index === -1) {
+                console.warn('Line not found. Package probably fixed.');
+                return;
+            }
+
+            var result = data.replace(
+                'await connection.run(`PRAGMA foreign_keys = ON`);',
+                'await connection.execute(`PRAGMA foreign_keys = ON`, false);'
+            );
+
+            result = result.replace(
+                'await connection.run(`PRAGMA journal_mode = ${this.options.journalMode}`);',
+                'await connection.execute(`PRAGMA journal_mode = ${this.options.journalMode}`, false);'
+            );
+
+            result += isModifiedKey;
+
+            fs.writeFile(file, result, 'utf8', function (err) {
+                if (err) return console.error(err);
+            });
+        });
+    } else {
+        utils.warn(`Couldn't find file ${file}`);
+    }
 }
-correctBugInCapacitorQueryRunner('./node_modules/typeorm/driver/capacitor/CapacitorQueryRunner.js');
-correctBugInCapacitorQueryRunner('./node_modules/typeorm/browser/driver/capacitor/CapacitorQueryRunner.js');
-correctBugInCapacitorDriver('./node_modules/typeorm/driver/capacitor/CapacitorDriver.js');
-correctBugInCapacitorDriver('./node_modules/typeorm/browser/driver/capacitor/CapacitorDriver.js');
-
  ```
+
+ - In your `package.json` add `"postinstall": "node ./scripts/modify-typeorm.cjs"` or for ESModule: `"postinstall": "npx tsx ./scripts/modify-typeorm.js"`
 
 
 


### PR DESCRIPTION
feat: added `isModifiedKey` to both bug correction examples to prevent double modifications causing file to contain errors.
docs: Additional step for adding to `package.json` -> `postinstall` script
docs: Alternative for esmodule so you don't get type errors