### PR TITLE
corrected reference to "sql-wasm.wasm" file location in Web Usage doc

### DIFF
--- a/docs/Web-Usage.md
+++ b/docs/Web-Usage.md
@@ -33,7 +33,7 @@ npm i --save jeep-sqlite@latest
 ## Ionic/Angular App
 
 - **sql-wasm.wasm** 
-   - Either copy manually the file `sql-wasm.wasm` from `nodes_modules/sql.js/dist/sql-wasm.wasm` to the `src/assets` folder of YOUR_APP 
+   - Either copy manually the file `sql-wasm.wasm` from `node_modules/sql.js/dist/sql-wasm.wasm` to the `src/assets` folder of YOUR_APP 
    - or `npm i --save-dev copyfiles` and modify the scripts in the `package.json` file as follows:
 
      ```
@@ -707,7 +707,7 @@ that is it.
 
 ## Ionic/Vue App
 
-- copy manually the file `sql-wasm.wasm` from `nodes_modules/sql.js/dist/sql-wasm.wasm` to the `public/assets` folder of YOUR_APP 
+- copy manually the file `sql-wasm.wasm` from `node_modules/sql.js/dist/sql-wasm.wasm` to the `public/assets` folder of YOUR_APP 
 
 - For databases in the `public/assets/databases` folder if any, you have to create a `databases.json` file which includes only the non-encrypted database's names
 
@@ -1112,7 +1112,7 @@ that is it.
 
 ## Ionic/React App
 
-- copy manually the file `sql-wasm.wasm` from `nodes_modules/sql.js/dist/sql-wasm.wasm` to the `public/assets` folder of YOUR_APP 
+- copy manually the file `sql-wasm.wasm` from `node_modules/sql.js/dist/sql-wasm.wasm` to the `public/assets` folder of YOUR_APP 
 
 - For databases in the `public/assets/databases` folder if any, you have to create a `databases.json` file which includes only the non-encrypted database's names
 


### PR DESCRIPTION
`nodes_modules/sql.js/dist/sql-wasm.wasm` does NOT exists.
`node_modules/sql.js/dist/sql-wasm.wasm` DOES exist.

```sh
stat nodes_modules/sql.js/dist/sql-wasm.wasm
stat: cannot statx 'nodes_modules/sql.js/dist/sql-wasm.wasm': No such file or directory

stat node_modules/sql.js/dist/sql-wasm.wasm
  File: node_modules/sql.js/dist/sql-wasm.wasm
  Size: 655300          Blocks: 1280       IO Block: 4096   regular file
Device: fc01h/64513d    Inode: 1106307     Links: 1
Access: (0775/-rwxrwxr-x)  Uid: ( 1001/ robkorv)   Gid: ( 1001/ robkorv)
Access: 2024-08-27 11:22:36.672917380 +0200
Modify: 2024-08-27 11:22:36.687917249 +0200
Change: 2024-08-27 11:22:36.687917249 +0200
 Birth: 2024-08-27 11:22:36.672917380 +0200
```