### PR TITLE
fix(electron): `file is not a database` error when opening a database

### DIFF
--- a/electron/src/electron-utils/utilsSQLite.ts
+++ b/electron/src/electron-utils/utilsSQLite.ts
@@ -55,13 +55,6 @@ export class UtilsSQLite {
     }
     if (mDB != null) {
       try {
-        this.dbChanges(mDB);
-      } catch (err: any) {
-        const errmsg = err.message ? err.message : err;
-        throw new Error(`${msg} ${errmsg}`);
-      }
-
-      try {
         // set the password
         if (password.length > 0) {
           this.setCipherPragma(mDB, password);
@@ -72,6 +65,14 @@ export class UtilsSQLite {
         const errmsg = err.message ? err.message : err;
         throw new Error(`${msg} ${errmsg}`);
       }
+
+      try {
+        this.dbChanges(mDB);
+      } catch (err: any) {
+        const errmsg = err.message ? err.message : err;
+        throw new Error(`${msg} ${errmsg}`);
+      }
+
       return mDB;
     } else {
       throw new Error(msg + 'open database failed');


### PR DESCRIPTION
I was getting "file is not a database" error during opening existing "secret" mode database. I realized that we are trying to execute statement before passphrase provided to sqlite.

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [x] The changes have been tested successfully.

Close #638