### PR TITLE
fix(android): update sqlcipher-android dependency to version 4.10.0

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -61,7 +61,7 @@ dependencies {
     androidTestImplementation "androidx.test.ext:junit:$androidxJunitVersion"
     androidTestImplementation "androidx.test.espresso:espresso-core:$androidxEspressoCoreVersion"
     implementation "androidx.coordinatorlayout:coordinatorlayout:1.2.0"
-    implementation 'net.zetetic:sqlcipher-android:4.6.1@aar'
+    implementation 'net.zetetic:sqlcipher-android:4.10.0@aar'
     implementation "androidx.sqlite:sqlite:2.4.0"
     //security library
     implementation "androidx.security:security-crypto:1.1.0-alpha06"


### PR DESCRIPTION
Fix #660 

As @dmoojunk suggested, updating the dependency fixes this error. I've tested the changes in a test project and everything seems to work correctly. I also made sure that the sqlcipher library didn't have a breaking change.

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [x] The changes have been tested successfully.
