### PR TITLE
fix(android): update sqlcipher-android dependency to version 4.17.0

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -61,7 +61,7 @@ dependencies {
     androidTestImplementation "androidx.test.ext:junit:$androidxJunitVersion"
     androidTestImplementation "androidx.test.espresso:espresso-core:$androidxEspressoCoreVersion"
     implementation "androidx.coordinatorlayout:coordinatorlayout:1.2.0"
-    implementation 'net.zetetic:sqlcipher-android:4.10.0@aar'
+    implementation 'net.zetetic:sqlcipher-android:4.17.0@aar'
     implementation "androidx.sqlite:sqlite:2.4.0"
     //security library
     implementation "androidx.security:security-crypto:1.1.0-alpha06"


### PR DESCRIPTION
Updates `net.zetetic:sqlcipher-android` from 4.10.0 to 4.17.0, the latest release on Maven Central. Same shape as #664, which brought it to 4.10.0.

Motivation beyond staying current: the iOS side's `SQLCipher` pod dependency is unpinned, so fresh iOS installs already resolve to the newest SQLCipher 4.x and its SQLite 3.53 baseline, while Android stays on 4.10's older SQLite. This bump brings the two platforms back to the same SQLite generation.

Verified locally on macOS: `cd android && ./gradlew build` succeeds against 4.17.0, unit tests included.

Non-blocking side note: pinning the iOS pod to `~> 4.0` would make iOS resolution deterministic within the 4.x line; happy to file that separately if wanted.
